### PR TITLE
feat: add slack_add_reaction and slack_remove_reaction tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/
+node_modules/

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,13 @@
         "clientId": "1601185624273.8899143856786",
         "callbackPort": 3118
       }
+    },
+    "slack-reactions": {
+      "command": "npx",
+      "args": ["tsx", "./src/reactions.ts"],
+      "env": {
+        "SLACK_BOT_TOKEN": ""
+      }
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,3 +14,28 @@ This plugin integrates Slack with Claude Code, providing tools to search, read, 
 
 - **slack-messaging** — Guidance for composing well-formatted Slack messages using standard markdown
 - **slack-search** — Guidance for effectively searching Slack to find messages, files, channels, and people
+
+## Emoji Reactions
+
+The `slack-reactions` MCP server adds `slack_add_reaction` and `slack_remove_reaction` tools. It runs as a local subprocess and calls the Slack Web API directly.
+
+### Tools
+
+- **slack_add_reaction** — Add an emoji reaction to a message (`channel_id`, `message_ts`, `emoji_name`)
+- **slack_remove_reaction** — Remove an emoji reaction from a message (`channel_id`, `message_ts`, `emoji_name`)
+
+### Setup
+
+Requires a Bot User OAuth Token (`xoxb-...`) with the `reactions:write` scope. Set it in `.mcp.json`:
+
+```json
+"slack-reactions": {
+  "command": "npx",
+  "args": ["tsx", "./src/reactions.ts"],
+  "env": {
+    "SLACK_BOT_TOKEN": "xoxb-your-token-here"
+  }
+}
+```
+
+Install dependencies first: `npm install`

--- a/README.md
+++ b/README.md
@@ -84,6 +84,57 @@ Add the following configuration to connect to the remote Slack MCP server:
 
 Save the configuration. You will also see a connect button once added. Click that to authenticate into your Slack Workspace.
 
+## Emoji Reactions
+
+The remote Slack MCP server does not support emoji reactions. This repo ships a lightweight local server (`src/reactions.ts`) that adds `slack_add_reaction` and `slack_remove_reaction` by calling the Slack Web API directly.
+
+### Slack App Setup
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps), open your app (or create one from scratch).
+2. Under **OAuth & Permissions → Bot Token Scopes**, add `reactions:write`.
+3. Reinstall the app to your workspace and copy the **Bot User OAuth Token** (`xoxb-...`).
+
+### Configuration
+
+Install the local dependencies:
+
+```bash
+npm install
+```
+
+Add your bot token to the `slack-reactions` entry in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp",
+      "oauth": {
+        "clientId": "1601185624273.8899143856786",
+        "callbackPort": 3118
+      }
+    },
+    "slack-reactions": {
+      "command": "npx",
+      "args": ["tsx", "./src/reactions.ts"],
+      "env": {
+        "SLACK_BOT_TOKEN": "xoxb-your-token-here"
+      }
+    }
+  }
+}
+```
+
+### Tools
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `slack_add_reaction` | `channel_id`, `message_ts`, `emoji_name` | Add an emoji reaction to a message |
+| `slack_remove_reaction` | `channel_id`, `message_ts`, `emoji_name` | Remove an emoji reaction from a message |
+
+`emoji_name` is the emoji name without colons — e.g. `thumbsup`, `white_check_mark`, `eyes`.
+
 ## Usage Examples
 
 Once configured, you can interact with Slack through your AI assistant using natural language:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "slack-mcp-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.28.0",
+    "@slack/web-api": "^7.0.0",
+    "tsx": "^4.19.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "private": true,
+  "scripts": {
+    "test": "vitest run"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@slack/web-api": "^7.0.0",
@@ -10,6 +13,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "typescript": "^5.8.0"
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/skills/slack-messaging/SKILL.md
+++ b/skills/slack-messaging/SKILL.md
@@ -49,5 +49,5 @@ Not supported:
 ## Tone and Audience
 
 - Match the tone to the channel — `#general` is usually more formal than `#random`.
-- Use emoji reactions instead of reply messages for simple acknowledgments (though note: the MCP tools can't add reactions, so suggest the user do this manually if appropriate).
+- Use emoji reactions instead of reply messages for simple acknowledgments. Use `slack_add_reaction` if the `slack-reactions` server is configured; otherwise suggest the user add the reaction manually.
 - When writing announcements, use a clear structure: context, key info, call to action.

--- a/src/reactions.ts
+++ b/src/reactions.ts
@@ -2,16 +2,16 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { WebClient } from '@slack/web-api'
+import { fileURLToPath } from 'node:url'
 
-const token = process.env.SLACK_BOT_TOKEN
-if (!token?.startsWith('xoxb-')) {
-  console.error('[slack-reactions] SLACK_BOT_TOKEN is missing or invalid (must start with xoxb-)')
-  process.exit(1)
+interface SlackReactionsClient {
+  reactions: {
+    add: (params: { channel: string; timestamp: string; name: string }) => Promise<unknown>
+    remove: (params: { channel: string; timestamp: string; name: string }) => Promise<unknown>
+  }
 }
 
-const slack = new WebClient(token)
-
-const TOOLS = [
+export const TOOLS = [
   {
     name: 'slack_add_reaction',
     description: 'Add an emoji reaction to a Slack message',
@@ -40,25 +40,19 @@ const TOOLS = [
   },
 ]
 
-const server = new Server(
-  { name: 'slack-reactions', version: '1.0.0' },
-  { capabilities: { tools: {} } },
-)
-
-server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }))
-
-server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  const { name, arguments: args } = req.params
-  const a = args as Record<string, string>
-
+export async function handleToolCall(
+  slack: SlackReactionsClient,
+  name: string,
+  args: Record<string, string>,
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
   try {
     switch (name) {
       case 'slack_add_reaction':
-        await slack.reactions.add({ channel: a.channel_id, timestamp: a.message_ts, name: a.emoji_name })
+        await slack.reactions.add({ channel: args.channel_id, timestamp: args.message_ts, name: args.emoji_name })
         return { content: [{ type: 'text', text: 'reaction added' }] }
 
       case 'slack_remove_reaction':
-        await slack.reactions.remove({ channel: a.channel_id, timestamp: a.message_ts, name: a.emoji_name })
+        await slack.reactions.remove({ channel: args.channel_id, timestamp: args.message_ts, name: args.emoji_name })
         return { content: [{ type: 'text', text: 'reaction removed' }] }
 
       default:
@@ -67,6 +61,32 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   } catch (err) {
     return { content: [{ type: 'text', text: `error: ${(err as Error).message}` }], isError: true }
   }
-})
+}
 
-await server.connect(new StdioServerTransport())
+export function createServer(slack: SlackReactionsClient): Server {
+  const server = new Server(
+    { name: 'slack-reactions', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  )
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }))
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args } = req.params
+    return handleToolCall(slack, name, args as Record<string, string>)
+  })
+
+  return server
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const token = process.env.SLACK_BOT_TOKEN
+  if (!token?.startsWith('xoxb-')) {
+    console.error('[slack-reactions] SLACK_BOT_TOKEN is missing or invalid (must start with xoxb-)')
+    process.exit(1)
+  }
+
+  const slack = new WebClient(token)
+  const server = createServer(slack)
+  await server.connect(new StdioServerTransport())
+}

--- a/src/reactions.ts
+++ b/src/reactions.ts
@@ -1,0 +1,72 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { WebClient } from '@slack/web-api'
+
+const token = process.env.SLACK_BOT_TOKEN
+if (!token?.startsWith('xoxb-')) {
+  console.error('[slack-reactions] SLACK_BOT_TOKEN is missing or invalid (must start with xoxb-)')
+  process.exit(1)
+}
+
+const slack = new WebClient(token)
+
+const TOOLS = [
+  {
+    name: 'slack_add_reaction',
+    description: 'Add an emoji reaction to a Slack message',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        channel_id: { type: 'string', description: 'ID of the channel containing the message' },
+        message_ts: { type: 'string', description: 'Timestamp of the message to react to' },
+        emoji_name: { type: 'string', description: 'Emoji name without colons (e.g. thumbsup, white_check_mark, eyes)' },
+      },
+      required: ['channel_id', 'message_ts', 'emoji_name'],
+    },
+  },
+  {
+    name: 'slack_remove_reaction',
+    description: 'Remove an emoji reaction from a Slack message',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        channel_id: { type: 'string', description: 'ID of the channel containing the message' },
+        message_ts: { type: 'string', description: 'Timestamp of the message' },
+        emoji_name: { type: 'string', description: 'Emoji name without colons (e.g. thumbsup, white_check_mark, eyes)' },
+      },
+      required: ['channel_id', 'message_ts', 'emoji_name'],
+    },
+  },
+]
+
+const server = new Server(
+  { name: 'slack-reactions', version: '1.0.0' },
+  { capabilities: { tools: {} } },
+)
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }))
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const { name, arguments: args } = req.params
+  const a = args as Record<string, string>
+
+  try {
+    switch (name) {
+      case 'slack_add_reaction':
+        await slack.reactions.add({ channel: a.channel_id, timestamp: a.message_ts, name: a.emoji_name })
+        return { content: [{ type: 'text', text: 'reaction added' }] }
+
+      case 'slack_remove_reaction':
+        await slack.reactions.remove({ channel: a.channel_id, timestamp: a.message_ts, name: a.emoji_name })
+        return { content: [{ type: 'text', text: 'reaction removed' }] }
+
+      default:
+        throw new Error(`unknown tool: ${name}`)
+    }
+  } catch (err) {
+    return { content: [{ type: 'text', text: `error: ${(err as Error).message}` }], isError: true }
+  }
+})
+
+await server.connect(new StdioServerTransport())

--- a/tests/reactions.test.ts
+++ b/tests/reactions.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { TOOLS, handleToolCall } from '../src/reactions'
+
+function createMockSlack() {
+  return {
+    reactions: {
+      add: vi.fn(() => Promise.resolve({ ok: true })),
+      remove: vi.fn(() => Promise.resolve({ ok: true })),
+    },
+  }
+}
+
+describe('TOOLS definitions', () => {
+  test('exports slack_add_reaction and slack_remove_reaction', () => {
+    const names = TOOLS.map(t => t.name)
+    expect(names).toContain('slack_add_reaction')
+    expect(names).toContain('slack_remove_reaction')
+  })
+
+  test('slack_add_reaction requires channel_id, message_ts, emoji_name', () => {
+    const tool = TOOLS.find(t => t.name === 'slack_add_reaction')!
+    expect(tool.inputSchema.required).toEqual(['channel_id', 'message_ts', 'emoji_name'])
+  })
+
+  test('slack_remove_reaction requires channel_id, message_ts, emoji_name', () => {
+    const tool = TOOLS.find(t => t.name === 'slack_remove_reaction')!
+    expect(tool.inputSchema.required).toEqual(['channel_id', 'message_ts', 'emoji_name'])
+  })
+
+  test('emoji_name description mentions no colons', () => {
+    const tool = TOOLS.find(t => t.name === 'slack_add_reaction')!
+    expect(tool.inputSchema.properties.emoji_name.description).toContain('without colons')
+  })
+})
+
+describe('handleToolCall - slack_add_reaction', () => {
+  let mockSlack: ReturnType<typeof createMockSlack>
+
+  beforeEach(() => {
+    mockSlack = createMockSlack()
+  })
+
+  test('calls reactions.add with correct params', async () => {
+    await handleToolCall(mockSlack, 'slack_add_reaction', {
+      channel_id: 'C123',
+      message_ts: '1234.5678',
+      emoji_name: 'thumbsup',
+    })
+    expect(mockSlack.reactions.add).toHaveBeenCalledWith({
+      channel: 'C123',
+      timestamp: '1234.5678',
+      name: 'thumbsup',
+    })
+  })
+
+  test('returns success response', async () => {
+    const result = await handleToolCall(mockSlack, 'slack_add_reaction', {
+      channel_id: 'C123',
+      message_ts: '1234.5678',
+      emoji_name: 'thumbsup',
+    })
+    expect(result.content[0].text).toBe('reaction added')
+    expect(result.isError).toBeUndefined()
+  })
+
+  test('returns error response on API failure', async () => {
+    mockSlack.reactions.add.mockRejectedValueOnce(new Error('already_reacted'))
+    const result = await handleToolCall(mockSlack, 'slack_add_reaction', {
+      channel_id: 'C123',
+      message_ts: '1234.5678',
+      emoji_name: 'thumbsup',
+    })
+    expect(result.content[0].text).toContain('already_reacted')
+    expect(result.isError).toBe(true)
+  })
+
+  test('does not call reactions.remove', async () => {
+    await handleToolCall(mockSlack, 'slack_add_reaction', {
+      channel_id: 'C123',
+      message_ts: '1234.5678',
+      emoji_name: 'thumbsup',
+    })
+    expect(mockSlack.reactions.remove).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleToolCall - slack_remove_reaction', () => {
+  let mockSlack: ReturnType<typeof createMockSlack>
+
+  beforeEach(() => {
+    mockSlack = createMockSlack()
+  })
+
+  test('calls reactions.remove with correct params', async () => {
+    await handleToolCall(mockSlack, 'slack_remove_reaction', {
+      channel_id: 'C456',
+      message_ts: '9999.0001',
+      emoji_name: 'eyes',
+    })
+    expect(mockSlack.reactions.remove).toHaveBeenCalledWith({
+      channel: 'C456',
+      timestamp: '9999.0001',
+      name: 'eyes',
+    })
+  })
+
+  test('returns success response', async () => {
+    const result = await handleToolCall(mockSlack, 'slack_remove_reaction', {
+      channel_id: 'C456',
+      message_ts: '9999.0001',
+      emoji_name: 'eyes',
+    })
+    expect(result.content[0].text).toBe('reaction removed')
+    expect(result.isError).toBeUndefined()
+  })
+
+  test('returns error response on API failure', async () => {
+    mockSlack.reactions.remove.mockRejectedValueOnce(new Error('no_reaction'))
+    const result = await handleToolCall(mockSlack, 'slack_remove_reaction', {
+      channel_id: 'C456',
+      message_ts: '9999.0001',
+      emoji_name: 'eyes',
+    })
+    expect(result.content[0].text).toContain('no_reaction')
+    expect(result.isError).toBe(true)
+  })
+
+  test('does not call reactions.add', async () => {
+    await handleToolCall(mockSlack, 'slack_remove_reaction', {
+      channel_id: 'C456',
+      message_ts: '9999.0001',
+      emoji_name: 'eyes',
+    })
+    expect(mockSlack.reactions.add).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleToolCall - unknown tool', () => {
+  test('returns error response', async () => {
+    const mockSlack = createMockSlack()
+    const result = await handleToolCall(mockSlack, 'slack_unknown_tool', {})
+    expect(result.content[0].text).toContain('unknown tool')
+    expect(result.isError).toBe(true)
+  })
+
+  test('does not call any Slack API', async () => {
+    const mockSlack = createMockSlack()
+    await handleToolCall(mockSlack, 'slack_unknown_tool', {})
+    expect(mockSlack.reactions.add).not.toHaveBeenCalled()
+    expect(mockSlack.reactions.remove).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #31.

The remote MCP server at `mcp.slack.com` doesn't expose emoji reaction tools. This PR adds a minimal local MCP server (`src/reactions.ts`) that fills the gap by calling [`reactions.add`](https://api.slack.com/methods/reactions.add) and [`reactions.remove`](https://api.slack.com/methods/reactions.remove) from the Slack Web API directly.

### Design decisions

- **`@slack/web-api` not `@slack/bolt`** — no Socket Mode or event handling needed; only outbound HTTP calls to the Slack API
- **Single file** — the two tools have no shared state or helpers, so a single 72-line file is sufficient
- **Parallel to the remote server** — runs as a separate `slack-reactions` entry in `.mcp.json` alongside the existing `slack` remote server; users can enable it independently
- **Parameter naming** — `channel_id`, `message_ts`, `emoji_name` matches the names proposed in #31 and is consistent with the `channel_id` convention used in the remote server's tools

### New tools

| Tool | Parameters | Slack API |
|------|-----------|-----------|
| `slack_add_reaction` | `channel_id`, `message_ts`, `emoji_name` | `reactions.add` |
| `slack_remove_reaction` | `channel_id`, `message_ts`, `emoji_name` | `reactions.remove` |

`emoji_name` is without colons — e.g. `thumbsup`, `white_check_mark`, `eyes`.

### Required Slack app scope

`reactions:write` — add to an existing app's bot token scopes, or create a new app.

### Files changed

- `src/reactions.ts` — standalone MCP server (new)
- `package.json` — minimal deps: `@modelcontextprotocol/sdk`, `@slack/web-api`, `tsx` (new)
- `.mcp.json` — `slack-reactions` server entry
- `README.md` — setup instructions
- `CLAUDE.md` — tool reference
- `skills/slack-messaging/SKILL.md` — updated to reference `slack_add_reaction` instead of the "can't add reactions" caveat

### Relationship to PR #23

PR #23 adds a much larger feature (Socket Mode bridge for real-time Claude ↔ Slack messaging) and includes a `react` tool as part of that. This PR is intentionally minimal — just the two reaction tools, no event handling, no gating, no Socket Mode required.

## Test plan

- [ ] `npm install` succeeds
- [ ] `SLACK_BOT_TOKEN=xoxb-... npx tsx src/reactions.ts` starts without errors
- [ ] `slack_add_reaction` adds a reaction visible in Slack
- [ ] `slack_remove_reaction` removes it
- [ ] Missing/invalid token exits with a clear error message
- [ ] Calling with an invalid emoji name returns an error response (not a crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)