### PR TITLE
feat: add Codex marketplace @slack for production installs

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
-  "name": "slack-dev",
+  "name": "slack",
   "interface": {
-    "displayName": "Slack (dev)"
+    "displayName": "Slack"
   },
   "plugins": [
     {

--- a/.changeset/codex-production-marketplace.md
+++ b/.changeset/codex-production-marketplace.md
@@ -1,0 +1,19 @@
+---
+"slack": minor
+---
+
+Add the `slack` Codex marketplace, giving developers a production install path for the Slack plugin in Codex:
+
+```sh
+codex plugin marketplace add slackapi/slack-skills-plugin
+codex plugin add slack@slack
+```
+
+Codex resolves marketplace manifests from a fixed set of relative paths, so `.agents/plugins/marketplace.json` is the manifest developers get from this repo. It previously shipped as `slack-dev` with display name `Slack (dev)`, named for the plugin team's local testing rather than for the public install path it actually served, which made the install command read `slack@slack-dev`.
+
+If you installed under the old name, remove it before re-adding: Codex treats the two marketplaces as unrelated and will leave both installed and enabled.
+
+```sh
+codex plugin remove slack@slack-dev
+codex plugin marketplace remove slack-dev
+```

--- a/.changeset/codex-production-marketplace.md
+++ b/.changeset/codex-production-marketplace.md
@@ -9,7 +9,7 @@ codex plugin marketplace add slackapi/slack-skills-plugin
 codex plugin add slack@slack
 ```
 
-Codex resolves marketplace manifests from a fixed set of relative paths, so `.agents/plugins/marketplace.json` is the manifest developers get from this repo. It previously shipped as `slack-dev` with display name `Slack (dev)`, named for the plugin team's local testing rather than for the public install path it actually served, which made the install command read `slack@slack-dev`.
+Until now the only marketplace this repo published was named `slack-dev`, so installing the plugin meant adding a marketplace labelled "dev" and running `codex plugin add slack@slack-dev`.
 
 If you installed under the old name, remove it before re-adding: Codex treats the two marketplaces as unrelated and will leave both installed and enabled.
 

--- a/.changeset/rename-codex-marketplace.md
+++ b/.changeset/rename-codex-marketplace.md
@@ -1,5 +1,0 @@
----
-"slack": patch
----
-
-Rename the Codex marketplace in `.agents/plugins/marketplace.json` from `slack-dev` to `slack`, so the install command reads `codex plugin add slack@slack` instead of `slack@slack-dev`. The manifest was named for local testing, but Codex resolves marketplace manifests from a fixed set of relative paths, so this is also the manifest developers get when they run `codex plugin marketplace add slackapi/slack-skills-plugin`. Anyone who installed from the old name should run `codex plugin remove slack@slack-dev` and `codex plugin marketplace remove slack-dev` before re-adding.

--- a/.changeset/rename-codex-marketplace.md
+++ b/.changeset/rename-codex-marketplace.md
@@ -1,0 +1,5 @@
+---
+"slack": patch
+---
+
+Rename the Codex marketplace in `.agents/plugins/marketplace.json` from `slack-dev` to `slack`, so the install command reads `codex plugin add slack@slack` instead of `slack@slack-dev`. The manifest was named for local testing, but Codex resolves marketplace manifests from a fixed set of relative paths, so this is also the manifest developers get when they run `codex plugin marketplace add slackapi/slack-skills-plugin`. Anyone who installed from the old name should run `codex plugin remove slack@slack-dev` and `codex plugin marketplace remove slack-dev` before re-adding.

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -154,12 +154,12 @@ uninstall, in addition to removing the virtualenv and other generated files.)
 
 ### Testing in Codex
 
-Codex loads plugins only from a marketplace. The repo ships the `slack` marketplace at
-`.agents/plugins/marketplace.json`, which is both the public listing developers add
-with `codex plugin marketplace add slackapi/slack-skills-plugin` and the one you point
-at a local checkout for development.
+Codex loads plugins only from a marketplace, and a marketplace source can be a local
+directory, so your checkout serves as one. The repo ships the `slack` marketplace at
+`.agents/plugins/marketplace.json`, which is both the public listing and the local
+marketplace root you point Codex at while developing.
 
-Register your checkout as the marketplace and install the `slack` plugin:
+From the repo root, register the checkout as a marketplace and install the plugin from it:
 
 ```sh
 codex plugin marketplace add ./
@@ -167,6 +167,16 @@ codex plugin add slack@slack
 ```
 
 `codex plugin list` shows the plugin; `codex /plugins` opens the same flow interactively. Start a new Codex session to pick up the plugin, then invoke a skill by name with a `$` mention, for example `$block-kit`.
+
+**Re-run `codex plugin add slack@slack` after every change.** Installing copies your
+checkout into `~/.codex/plugins/cache/slack/slack/<version>/`, and Codex loads that copy
+rather than reading your working tree, so edits do not show up on their own. Re-running
+the install overwrites the copy in place, with no version bump required; start a new Codex
+session and the change is live. The copy is taken from the working tree, so uncommitted
+changes are picked up as-is and there is no need to commit first.
+
+`codex plugin marketplace upgrade` will not do this for you. It only refreshes Git
+marketplace snapshots, and errors on a marketplace added from a local path.
 
 To remove it
 

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -154,15 +154,16 @@ uninstall, in addition to removing the virtualenv and other generated files.)
 
 ### Testing in Codex
 
-Codex loads plugins only from a marketplace. The repo ships a development marketplace at
-`.agents/plugins/marketplace.json` that points at this checkout, so you can add
-it as a local marketplace and install the plugin from it.
+Codex loads plugins only from a marketplace. The repo ships the `slack` marketplace at
+`.agents/plugins/marketplace.json`, which is both the public listing developers add
+with `codex plugin marketplace add slackapi/slack-skills-plugin` and the one you point
+at a local checkout for development.
 
-Register the local marketplace and install the `slack` plugin:
+Register your checkout as the marketplace and install the `slack` plugin:
 
 ```sh
 codex plugin marketplace add ./
-codex plugin add slack@slack-dev
+codex plugin add slack@slack
 ```
 
 `codex plugin list` shows the plugin; `codex /plugins` opens the same flow interactively. Start a new Codex session to pick up the plugin, then invoke a skill by name with a `$` mention, for example `$block-kit`.
@@ -170,9 +171,14 @@ codex plugin add slack@slack-dev
 To remove it
 
 ```sh
-codex plugin remove slack@slack-dev
-codex plugin marketplace remove slack-dev
+codex plugin remove slack@slack
+codex plugin marketplace remove slack
 ```
+
+Codex resolves marketplace manifests from four hard-coded relative paths, so a
+separate `marketplace.dev.json` is not an option. Working on the plugin locally is
+handled by pointing Codex at your checkout, as above, rather than by shipping a
+second manifest.
 
 Codex support currently ships only the skills; the hosted MCP server is not yet wired into the Codex surface.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Slack MCP and Skills Plugin
 
-A [Claude Code][claude-code] and [Cursor][cursor] plugin that brings Slack into your AI tools with a [Slack MCP Server][slack-mcp-docs] and set of Slack skills for both users and developers.
+A [Claude Code][claude-code], [Cursor][cursor], and [Codex][codex-cli] plugin that brings Slack into your AI tools with a [Slack MCP Server][slack-mcp-docs] and set of Slack skills for both users and developers.
 
 [![CI Build](https://github.com/slackapi/slack-skills-plugin/actions/workflows/ci-build.yml/badge.svg)](https://github.com/slackapi/slack-skills-plugin/actions/workflows/ci-build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -26,6 +26,19 @@ The plugin is published on the [official Cursor Marketplace](https://cursor.com/
 ```
 
 This installs the skills, commands, and MCP server together. You'll be prompted to authenticate to your Slack workspace via OAuth on first use.
+
+### Codex
+
+The plugin is published as a Codex marketplace in this repository. Add the marketplace, then install the plugin:
+
+```sh
+codex plugin marketplace add slackapi/slack-skills-plugin
+codex plugin add slack@slack
+```
+
+Start a new Codex session to pick up the plugin, then invoke a skill by name with a `$` mention, for example `$block-kit`.
+
+Codex support currently ships the skills only; the MCP server is not yet wired into the Codex surface.
 
 ## Features
 
@@ -89,6 +102,7 @@ Working on the plugin itself? See the [maintainer's guide](.github/maintainers_g
 
 [claude-code]: https://claude.com/claude-code
 [cursor]: https://cursor.com
+[codex-cli]: https://developers.openai.com/codex/cli
 [slack-mcp-docs]: https://docs.slack.dev/ai/mcp-server/
 [slack-cli]: https://tools.slack.dev/slack-cli
 [bolt]: https://tools.slack.dev/bolt-js

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -1,6 +1,6 @@
 # Slack MCP and Skills Plugin
 
-The Slack MCP and Skills Plugin for AI tools bundles together a set of skills that help you develop on the Slack platform with the [Slack MCP Server](/ai/slack-mcp-server). You can use the plugin with Claude Code and Cursor.
+The Slack MCP and Skills Plugin for AI tools bundles together a set of skills that help you develop on the Slack platform with the [Slack MCP Server](/ai/slack-mcp-server). You can use the plugin with Claude Code, Cursor, and Codex.
 
 Installing the plugin sets up two things:
 
@@ -9,11 +9,13 @@ Installing the plugin sets up two things:
 
 The Slack MCP server is configured automatically when the plugin loads. You'll be prompted to authenticate into your Slack workspace via OAuth. Full setup details vary depending on the AI tool you are using.
 
+On Codex, the plugin installs the skills only. The Slack MCP server is not yet available on that surface, so there is no OAuth prompt.
+
 ---
 
 ## Installing the plugin
 
-You can install the plugin for Claude Code or for Cursor.
+You can install the plugin for Claude Code, Cursor, or Codex.
 
 ### Installing the plugin for Claude Code
 
@@ -32,6 +34,19 @@ The plugin is published on the [official Cursor Marketplace](https://cursor.com/
 ```
 
 Alternatively, search for "slack" in the Cursor plugin marketplace. This installs the skills, and MCP server together, and prompts OAuth to your Slack workspace on first use.
+
+### Installing the plugin for Codex
+
+The plugin is published as a marketplace in its [GitHub repository](https://github.com/slackapi/slack-skills-plugin). Add the marketplace, then install the plugin:
+
+```sh
+codex plugin marketplace add slackapi/slack-skills-plugin
+codex plugin add slack@slack
+```
+
+Start a new Codex session to pick up the plugin, then invoke a skill by name with a `$` mention, for example `$block-kit`.
+
+This installs the skills only. Because the Slack MCP server is not yet available on Codex, the `slack-search` skill cannot query your workspace there.
 
 ---
 

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -44,8 +44,6 @@ codex plugin marketplace add slackapi/slack-skills-plugin
 codex plugin add slack@slack
 ```
 
-Start a new Codex session to pick up the plugin, then invoke a skill by name with a `$` mention, for example `$block-kit`.
-
 This installs the skills only. Because the Slack MCP server is not yet available on Codex, the `slack-search` skill cannot query your workspace there.
 
 ---


### PR DESCRIPTION
### Summary

This pull request gives developers a production install path for the Slack plugin in Codex:

```sh
codex plugin marketplace add slackapi/slack-skills-plugin
codex plugin add slack@slack
```

Codex installs plugins only from a marketplace, and the one this repo publishes was named `slack-dev` after the plugin team's own testing rather than the audience it actually serves. That left `slack@slack-dev` as the only install path available to a public developer: adding a marketplace labelled "dev" in order to get the production release.

Promoting it to `slack` gives up the dev listing, which turns out to cost nothing. Codex accepts a local path as a marketplace source, so maintainers can test from a checkout with `codex plugin marketplace add ./` and never needed a published dev marketplace of their own. The README and the public plugin page in `docs/` are part of the same change, because both still advertised the plugin as Claude Code and Cursor only, and an install path developers cannot find is not a shipped install path.

### Preview

The install command developers are given:

```sh
# before — the only available path, labelled as dev
codex plugin add slack@slack-dev

# after
codex plugin add slack@slack
```

### Testing

Verified end-to-end against Codex CLI 0.146.1, then restored the machine to its pre-test state.

1. `codex plugin marketplace add ./` — the checkout registers and Codex resolves the manifest name as `slack`.
2. `codex plugin add slack@slack` — installs; `codex plugin list` shows the plugin enabled at 1.3.0 with all 8 skills.
3. `codex plugin remove slack@slack` and `codex plugin marketplace remove slack` — both clean up, matching the updated maintainers guide.

One finding worth flagging, because it makes the upgrade note below required rather than advisory: with a pre-existing `slack@slack-dev` install, adding `slack@slack` leaves **both** marketplaces installed and enabled at 1.3.0, exposing the same 8 skills. Codex does not recognize them as the same plugin, so the old entry has to be removed explicitly.

Locally, `make lint` (ruff + rumdl, 19 files), `make typecheck` (16 files), and `make test-unit` (21 tests) all pass.

CI: lint, typecheck, unit tests, and the evaluation tests all pass.

### Notes

**Upgrade note.** Anyone who installed under the old name should clean up before re-adding:

```sh
codex plugin remove slack@slack-dev
codex plugin marketplace remove slack-dev
```

That set should be small, since the marketplace has not been announced as a public install path yet. Doing the promotion now rather than after an announcement is what keeps it small.

**Naming.** Three marketplace IDs were considered: `slack`, `slackapi`, or keeping `slack-dev` and documenting it. `slack` was chosen as the cleanest match to the plugin name, giving `slack@slack`.

The display name `Slack` follows the dominant convention. Across the ~20 public repositories that currently ship a Codex `.agents/plugins/marketplace.json`, the bare brand name is what most use, and the alternatives rank well behind it:

- `Slack` — bare brand, ~55% of manifests (Firebase, Lepton, Virtuoso, StackQL, Inline)
- `Slack Skills` — brand plus "Skills", ~20% (Azure Agent Skills, Chris Banes Skills)
- `Slack Official` — brand plus an official qualifier, ~10% (OpenAI's own `Codex official` and `ChatGPT Official`)
- `Slack Marketplace` — brand plus "Marketplace", ~5% (a single manifest, and a local plugin listing rather than a published one)

The Codex schema defines the field as the user-facing *marketplace* title, so the surrounding UI already supplies that context. Sharing a display name with the plugin is also normal for a single-plugin repository: `firebase/agent-skills` uses `Firebase` for both, and `inline-chat/inline` uses `Inline` for both.

**Why no separate dev manifest.** Codex resolves marketplace manifests from four hard-coded relative paths, so shipping a `marketplace.dev.json` alongside a production one is not possible. Local development is handled by pointing Codex at a checkout (`codex plugin marketplace add ./`), which the maintainers guide now documents.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.
