### PR TITLE
chore: enable agents to update public docs when making public changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,19 @@ GitHub Actions (`.github/workflows/ci-build.yml`) gates every PR with:
 
 The eval job reads the `GEMINI_API_KEY_*` (e.g. `GEMINI_API_KEY_BOB`, `GEMINI_API_KEY_MIC`) and `SLACK_MCP_TOKEN` repository secrets; it skips on PRs from forks, which don't receive secrets. The workflow also runs nightly on a schedule, and a `notifications` job posts to Slack (via `SLACK_REGRESSION_FAILURES_WEBHOOK_URL`) when a job fails on `main`.
 
+## Public documentation
+
+`docs/` is published to [docs.slack.dev](https://docs.slack.dev/ai/slack-skills-plugin). The `slackapi/docs` repo syncs this directory from `main` (see its `sources.json`), so editing `docs/slack-skills-plugin.md` here is the whole job: there is no second PR to open, and the change goes live when it merges.
+
+**Any change to what a public developer can see or do must update `docs/` in the same PR.** Treat it like the changeset, not a follow-up. That includes:
+
+- A new install path, or a change to an existing install command
+- Adding, removing, or renaming a skill, which also means the skills table
+- A capability that differs by surface (Claude Code, Cursor, Codex): say so explicitly rather than leaving a developer to infer it
+- Anything that makes an existing statement on the page wrong, including the list of supported tools
+
+`README.md` covers the same ground for people arriving via GitHub, so the same PR usually needs the matching edit there. Check both.
+
 ## Releasing
 
 Releases are automated and run in CI: **you never run a release yourself.** Your only release-related task is adding a changeset when a PR makes a user-facing change.


### PR DESCRIPTION
### Summary

This pull request tells agents working in this repo that a public-facing change is not done until `docs/` is updated, so the page developers actually read stops trailing the code by a PR.

`AGENTS.md` covers commands, cross-skill references, skill descriptions, testing, CI, and releasing, but says nothing about `docs/`. An agent adding a public capability therefore has no reason to open `docs/slack-skills-plugin.md`, and the connection to docs.slack.dev is not discoverable from this repo at all: the sync lives in `slackapi/docs`, in a `sources.json` entry pointing at this directory on `main`.

The new `## Public documentation` section states where `docs/` goes and that the edit belongs in the same PR, then enumerates what counts: a new or changed install command, a skill added/removed/renamed (and so the skills table), a capability that differs by surface, and anything that makes an existing statement on the page wrong. It closes by pointing at `README.md` as the same obligation for people arriving via GitHub.

### Testing

No changeset: `AGENTS.md` is agent guidance, not a user-facing change, so it does not belong in the published CHANGELOG.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.
