### PR TITLE
feat: add 'npx skills' support for other agents

### DIFF
--- a/.changeset/npx-skills-install-path.md
+++ b/.changeset/npx-skills-install-path.md
@@ -2,7 +2,7 @@
 "slack": patch
 ---
 
-Document installing the skills with the `skills` CLI, which reaches 77 agents beyond the three with a plugin surface (Gemini CLI, OpenCode, Zed, Warp, Amp, and more):
+Document installing the skills with the `skills` CLI, which reaches 77 agents beyond the three with a plugin surface (Crush, Devin, Gemini CLI, Hermes, OpenClaw, OpenCode, Pi, and more):
 
 ```sh
 npx skills add slackapi/slack-skills-plugin -a <agent>

--- a/.changeset/npx-skills-install-path.md
+++ b/.changeset/npx-skills-install-path.md
@@ -4,7 +4,11 @@
 
 Document installing the skills with `npx skills`, which reaches coding agents beyond the three with a plugin surface:
 
-```sh
+```bash
+# Install the skills for a coding agent, named by its own identifier
+npx skills add slackapi/slack-skills-plugin -a <agent>
+
+# For example, Gemini CLI or OpenCode
 npx skills add slackapi/slack-skills-plugin -a gemini-cli
 npx skills add slackapi/slack-skills-plugin -a opencode
 ```

--- a/.changeset/npx-skills-install-path.md
+++ b/.changeset/npx-skills-install-path.md
@@ -2,10 +2,11 @@
 "slack": patch
 ---
 
-Document installing the skills with the `skills` CLI, which reaches 77 agents beyond the three with a plugin surface (Crush, Devin, Gemini CLI, Hermes, OpenClaw, OpenCode, Pi, and more):
+Document installing the skills with `npx skills`, which reaches coding agents beyond the three with a plugin surface:
 
 ```sh
-npx skills add slackapi/slack-skills-plugin -a <agent>
+npx skills add slackapi/slack-skills-plugin -a gemini-cli
+npx skills add slackapi/slack-skills-plugin -a opencode
 ```
 
 This path already worked and needed no changes here, it was just undocumented. It carries the skills only: no commands, and no MCP server.

--- a/.changeset/npx-skills-install-path.md
+++ b/.changeset/npx-skills-install-path.md
@@ -1,0 +1,11 @@
+---
+"slack": patch
+---
+
+Document installing the skills with the `skills` CLI, which reaches 77 agents beyond the three with a plugin surface (Gemini CLI, OpenCode, Zed, Warp, Amp, and more):
+
+```sh
+npx skills add slackapi/slack-skills-plugin -a <agent>
+```
+
+This path already worked and needed no changes here, it was just undocumented. It carries the skills only: no commands, and no MCP server.

--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ Codex support currently ships the skills only; the MCP server is not yet wired i
 
 ### Other agents
 
-The skills install into any of the 77 agents supported by the [`skills` CLI][skills-cli], including Gemini CLI, OpenCode, Zed, Warp, and Amp, with no plugin marketplace required for that agent:
+The skills install into any of the 77 agents supported by the [`skills` CLI][skills-cli], with no plugin marketplace required for that agent:
 
 ```sh
 npx skills add slackapi/slack-skills-plugin -a <agent>
 ```
 
-Pass the agent's own identifier (`gemini-cli`, `opencode`, `zed`), repeat `-a` for several at once, or use `-a '*'` for every agent it detects. `--list` previews the skills without installing them, and `-g` installs for your user instead of the current project.
+Name the agent with its own identifier, for example `crush`, `devin`, `gemini-cli`, `hermes-agent`, `openclaw`, `opencode`, or `pi`. Repeat `-a` to reach several at once, or use `-a '*'` for every agent it detects. `--list` previews the skills without installing them, and `-g` installs for your user instead of the current project.
 
-Skills land in the agent's project directory (`.agents/skills/` for most agents, `.claude/skills/` for Claude Code), and a `skills-lock.json` at the project root records a hash per skill so `npx skills update` re-syncs them after a release here.
+Skills land in whichever project directory that agent reads (`.agents/skills/` for Gemini CLI and OpenCode, `.crush/skills/` for Crush, `.claude/skills/` for Claude Code), and a `skills-lock.json` at the project root records a hash per skill so `npx skills update` re-syncs them after a release here.
 
 This path carries the skills only: no commands, and no MCP server.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Codex support currently ships the skills only; the MCP server is not yet wired i
 
 The skills install into other coding agents with [`npx skills`][npx-skills], no plugin marketplace required:
 
-```sh
+```bash
+# Install the skills for a coding agent, named by its own identifier
+npx skills add slackapi/slack-skills-plugin -a <agent>
+
+# For example, Gemini CLI or OpenCode
 npx skills add slackapi/slack-skills-plugin -a gemini-cli
 npx skills add slackapi/slack-skills-plugin -a opencode
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ Start a new Codex session to pick up the plugin, then invoke a skill by name wit
 
 Codex support currently ships the skills only; the MCP server is not yet wired into the Codex surface.
 
+### Other agents
+
+The skills install into any of the 77 agents supported by the [`skills` CLI][skills-cli], including Gemini CLI, OpenCode, Zed, Warp, and Amp, with no plugin marketplace required for that agent:
+
+```sh
+npx skills add slackapi/slack-skills-plugin -a <agent>
+```
+
+Pass the agent's own identifier (`gemini-cli`, `opencode`, `zed`), repeat `-a` for several at once, or use `-a '*'` for every agent it detects. `--list` previews the skills without installing them, and `-g` installs for your user instead of the current project.
+
+Skills land in the agent's project directory (`.agents/skills/` for most agents, `.claude/skills/` for Claude Code), and a `skills-lock.json` at the project root records a hash per skill so `npx skills update` re-syncs them after a release here.
+
+This path carries the skills only: no commands, and no MCP server.
+
 ## Features
 
 ### MCP Server
@@ -104,6 +118,7 @@ Working on the plugin itself? See the [maintainer's guide](.github/maintainers_g
 [cursor]: https://cursor.com
 [codex-cli]: https://developers.openai.com/codex/cli
 [slack-mcp-docs]: https://docs.slack.dev/ai/mcp-server/
+[skills-cli]: https://github.com/vercel-labs/skills#supported-agents
 [slack-cli]: https://tools.slack.dev/slack-cli
 [bolt]: https://tools.slack.dev/bolt-js
 [block-kit]: https://app.slack.com/block-kit-builder

--- a/README.md
+++ b/README.md
@@ -42,15 +42,14 @@ Codex support currently ships the skills only; the MCP server is not yet wired i
 
 ### Other agents
 
-The skills install into any of the 77 agents supported by the [`skills` CLI][skills-cli], with no plugin marketplace required for that agent:
+The skills install into other coding agents with [`npx skills`][npx-skills], no plugin marketplace required:
 
 ```sh
-npx skills add slackapi/slack-skills-plugin -a <agent>
+npx skills add slackapi/slack-skills-plugin -a gemini-cli
+npx skills add slackapi/slack-skills-plugin -a opencode
 ```
 
-Name the agent with its own identifier, for example `crush`, `devin`, `gemini-cli`, `hermes-agent`, `openclaw`, `opencode`, or `pi`. Repeat `-a` to reach several at once, or use `-a '*'` for every agent it detects. `--list` previews the skills without installing them, and `-g` installs for your user instead of the current project.
-
-Skills land in whichever project directory that agent reads (`.agents/skills/` for Gemini CLI and OpenCode, `.crush/skills/` for Crush, `.claude/skills/` for Claude Code), and a `skills-lock.json` at the project root records a hash per skill so `npx skills update` re-syncs them after a release here.
+Other popular agents include `crush`, `devin`, `hermes-agent`, `openclaw`, and `pi`. See [supported agents][npx-skills] for the full list of agents and their identifiers. Add `-g` to install for your user instead of the current project.
 
 This path carries the skills only: no commands, and no MCP server.
 
@@ -118,7 +117,7 @@ Working on the plugin itself? See the [maintainer's guide](.github/maintainers_g
 [cursor]: https://cursor.com
 [codex-cli]: https://developers.openai.com/codex/cli
 [slack-mcp-docs]: https://docs.slack.dev/ai/mcp-server/
-[skills-cli]: https://github.com/vercel-labs/skills#supported-agents
+[npx-skills]: https://github.com/vercel-labs/skills#supported-agents
 [slack-cli]: https://tools.slack.dev/slack-cli
 [bolt]: https://tools.slack.dev/bolt-js
 [block-kit]: https://app.slack.com/block-kit-builder

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -61,7 +61,7 @@ npx skills add slackapi/slack-skills-plugin -a opencode
 
 Other popular agents include `crush`, `devin`, `hermes-agent`, `openclaw`, and `pi`. See [supported agents](https://github.com/vercel-labs/skills#supported-agents) for the full list of agents and their identifiers.
 
-This installs the skills only. There is no MCP server on this path, so the `slack-search` skill cannot query your workspace.
+This installs the skills only. There is no MCP server on this path, which causes some issues (e.g., the slack-search skill cannot query your workspace).
 
 ---
 

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -1,6 +1,6 @@
 # Slack MCP and Skills Plugin
 
-The Slack MCP and Skills Plugin for AI tools bundles together a set of skills that help you develop on the Slack platform with the [Slack MCP Server](/ai/slack-mcp-server). You can use the plugin with Claude Code, Cursor, and Codex.
+The Slack MCP and Skills Plugin for AI tools bundles together a set of skills that help you develop on the Slack platform with the [Slack MCP Server](/ai/slack-mcp-server). You can use the plugin with Claude Code, Cursor, and Codex, and you can install the skills on their own into dozens of other agents.
 
 Installing the plugin sets up two things:
 
@@ -15,7 +15,7 @@ On Codex, the plugin installs the skills only. The Slack MCP server is not yet a
 
 ## Installing the plugin
 
-You can install the plugin for Claude Code, Cursor, or Codex.
+You can install the plugin for Claude Code, Cursor, or Codex, or install the skills on their own for another agent.
 
 ### Installing the plugin for Claude Code
 
@@ -45,6 +45,18 @@ codex plugin add slack@slack
 ```
 
 This installs the skills only. Because the Slack MCP server is not yet available on Codex, the `slack-search` skill cannot query your workspace there.
+
+### Installing the skills for another agent
+
+The skills can be installed on their own into any of the 77 agents supported by the [`skills` CLI](https://github.com/vercel-labs/skills#supported-agents), including Gemini CLI, OpenCode, Zed, and Warp:
+
+```sh
+npx skills add slackapi/slack-skills-plugin -a <agent>
+```
+
+Pass the agent's own identifier (`gemini-cli`, `opencode`, `zed`), or use `-a '*'` for every agent detected in your project. Add `--list` to see the available skills without installing them.
+
+This installs the skills only. There is no MCP server on this path, so the `slack-search` skill cannot query your workspace.
 
 ---
 

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -50,7 +50,11 @@ This installs the skills only. Because the Slack MCP server is not yet available
 
 The skills can be installed on their own into other coding agents with [`npx skills`](https://github.com/vercel-labs/skills), naming the agent you want:
 
-```sh
+```bash
+# Install the skills for a coding agent, named by its own identifier
+npx skills add slackapi/slack-skills-plugin -a <agent>
+
+# For example, Gemini CLI or OpenCode
 npx skills add slackapi/slack-skills-plugin -a gemini-cli
 npx skills add slackapi/slack-skills-plugin -a opencode
 ```

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -1,6 +1,6 @@
 # Slack MCP and Skills Plugin
 
-The Slack MCP and Skills Plugin for AI tools bundles together a set of skills that help you develop on the Slack platform with the [Slack MCP Server](/ai/slack-mcp-server). You can use the plugin with Claude Code, Cursor, and Codex, and you can install the skills on their own into dozens of other agents.
+The Slack MCP and Skills Plugin for AI tools bundles together a set of skills that help you develop on the Slack platform with the [Slack MCP Server](/ai/slack-mcp-server). You can use the plugin with Claude Code, Cursor, Codex, and other coding agents.
 
 Installing the plugin sets up two things:
 
@@ -15,7 +15,7 @@ On Codex, the plugin installs the skills only. The Slack MCP server is not yet a
 
 ## Installing the plugin
 
-You can install the plugin for Claude Code, Cursor, or Codex, or install the skills on their own for another agent.
+You can install the plugin for Claude Code, Cursor, Codex, and other coding agents.
 
 ### Installing the plugin for Claude Code
 
@@ -46,27 +46,16 @@ codex plugin add slack@slack
 
 This installs the skills only. Because the Slack MCP server is not yet available on Codex, the `slack-search` skill cannot query your workspace there.
 
-### Installing the skills for another agent
+### Installing the skills for other agents
 
-The skills can be installed on their own into any of the 77 agents supported by the [`skills` CLI](https://github.com/vercel-labs/skills#supported-agents):
+The skills can be installed on their own into other coding agents with [`npx skills`](https://github.com/vercel-labs/skills), naming the agent you want:
 
 ```sh
-npx skills add slackapi/slack-skills-plugin -a <agent>
+npx skills add slackapi/slack-skills-plugin -a gemini-cli
+npx skills add slackapi/slack-skills-plugin -a opencode
 ```
 
-Name the agent with its own identifier. A few of the popular ones, along with where each installs the skills in your project:
-
-| Agent | Identifier | Skills directory |
-|-------|------------|------------------|
-| Crush | `crush` | `.crush/skills/` |
-| Devin for Terminal | `devin` | `.devin/skills/` |
-| Gemini CLI | `gemini-cli` | `.agents/skills/` |
-| Hermes Agent | `hermes-agent` | `.hermes/skills/` |
-| OpenClaw | `openclaw` | `skills/` |
-| OpenCode | `opencode` | `.agents/skills/` |
-| Pi | `pi` | `.pi/skills/` |
-
-Repeat `-a` to reach several agents at once, or use `-a '*'` for every agent detected in your project. Add `--list` to see the available skills without installing them.
+Other popular agents include `crush`, `devin`, `hermes-agent`, `openclaw`, and `pi`. See [supported agents](https://github.com/vercel-labs/skills#supported-agents) for the full list of agents and their identifiers.
 
 This installs the skills only. There is no MCP server on this path, so the `slack-search` skill cannot query your workspace.
 

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -48,13 +48,25 @@ This installs the skills only. Because the Slack MCP server is not yet available
 
 ### Installing the skills for another agent
 
-The skills can be installed on their own into any of the 77 agents supported by the [`skills` CLI](https://github.com/vercel-labs/skills#supported-agents), including Gemini CLI, OpenCode, Zed, and Warp:
+The skills can be installed on their own into any of the 77 agents supported by the [`skills` CLI](https://github.com/vercel-labs/skills#supported-agents):
 
 ```sh
 npx skills add slackapi/slack-skills-plugin -a <agent>
 ```
 
-Pass the agent's own identifier (`gemini-cli`, `opencode`, `zed`), or use `-a '*'` for every agent detected in your project. Add `--list` to see the available skills without installing them.
+Name the agent with its own identifier. A few of the popular ones, along with where each installs the skills in your project:
+
+| Agent | Identifier | Skills directory |
+|-------|------------|------------------|
+| Crush | `crush` | `.crush/skills/` |
+| Devin for Terminal | `devin` | `.devin/skills/` |
+| Gemini CLI | `gemini-cli` | `.agents/skills/` |
+| Hermes Agent | `hermes-agent` | `.hermes/skills/` |
+| OpenClaw | `openclaw` | `skills/` |
+| OpenCode | `opencode` | `.agents/skills/` |
+| Pi | `pi` | `.pi/skills/` |
+
+Repeat `-a` to reach several agents at once, or use `-a '*'` for every agent detected in your project. Add `--list` to see the available skills without installing them.
 
 This installs the skills only. There is no MCP server on this path, so the `slack-search` skill cannot query your workspace.
 


### PR DESCRIPTION
### Summary

This pull request documents how to install the Slack skills into coding agents that have no plugin marketplace, so a developer on Gemini CLI, OpenCode, or anything else `npx skills` supports is no longer told this plugin is for Claude Code, Cursor, and Codex only.

```bash
# Install the skills for a coding agent, named by its own identifier
npx skills add slackapi/slack-skills-plugin -a <agent>

# For example, Gemini CLI or OpenCode
npx skills add slackapi/slack-skills-plugin -a gemini-cli
npx skills add slackapi/slack-skills-plugin -a opencode
```

Docs only. This path already worked and was simply undocumented. The README gains an **Other agents** section and `docs/slack-skills-plugin.md` gains the matching one, both linking to [supported agents](https://github.com/vercel-labs/skills#supported-agents) rather than mirroring a list that changes every release. Both say what the path costs you: skills only, no commands, and no MCP server, so `slack-search` cannot query a workspace.

### Notes

- How to *update* an install is undocumented on every surface, not just this one. Tracked separately.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.
