### PR TITLE
ci: migrate changesets/action release workflow to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,20 +40,19 @@ jobs:
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          version: bash scripts/changeset_version.sh
-          publish: npx changeset publish
-          createGithubReleases: true
-          commit: "chore: release"
-          title: "chore: release"
-          prDraft: create
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: release"
+          create-github-releases: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-draft: create
+          pr-title: "chore: release"
+          publish-script: npx changeset publish
+          version-script: bash scripts/changeset_version.sh
       - name: Get publication details
         id: release
         if: steps.changesets.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
         run: |
           echo "url=$(gh release view --json url -q .url)" >> "$GITHUB_OUTPUT"
           echo "message=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | "\(.name)@\(.version)"' | paste -sd ', ' -)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Summary

`changesets/action` v2 introduced three breaking changes to the release workflow interface:

1. [Renamed the root action inputs](https://github.com/changesets/action/pull/681) to kebab-case (`version` → `version-script`, `commit` → `commit-message`, etc.).
2. [Renamed the outputs](https://github.com/changesets/action/pull/681) (`hasChangesets` → `has-changesets`, `publishedPackages` → `published-packages`).
3. [Now pushes release commits/tags via the GitHub API by default](https://github.com/changesets/action/pull/692), and the token **must** be passed through the `github-token` **input** — the `GITHUB_TOKEN` env var / `actions/checkout` credentials are no longer a substitute.

The action bump only updated the pinned SHA, leaving the workflow on the v1 interface: v2 would silently ignore the inputs (falling back to defaults), resolve the renamed outputs to empty, and lose the token for the API push.

This migrates the workflow to the v2 interface — renamed inputs (alphabetized) + outputs, and the token moved into the `github-token` input. Values unchanged; verified against [`action.yml` at the pinned v2.1.1 SHA](https://github.com/changesets/action/blob/8488615a623b1b9c987934bb89eae8af6a946ac1/action.yml), matching the already-migrated node-slack-sdk release workflow.