### PR TITLE
docs: add -y to the npx skills install commands

### DIFF
--- a/.changeset/npx-skills-install-path.md
+++ b/.changeset/npx-skills-install-path.md
@@ -6,11 +6,11 @@ Document installing the skills with `npx skills`, which reaches coding agents be
 
 ```bash
 # Install the skills for a coding agent, named by its own identifier
-npx skills add slackapi/slack-skills-plugin -a <agent>
+npx skills add slackapi/slack-skills-plugin -y -a <agent>
 
 # For example, Gemini CLI or OpenCode
-npx skills add slackapi/slack-skills-plugin -a gemini-cli
-npx skills add slackapi/slack-skills-plugin -a opencode
+npx skills add slackapi/slack-skills-plugin -y -a gemini-cli
+npx skills add slackapi/slack-skills-plugin -y -a opencode
 ```
 
 This path already worked and needed no changes here, it was just undocumented. It carries the skills only: no commands, and no MCP server.

--- a/README.md
+++ b/README.md
@@ -46,14 +46,16 @@ The skills install into other coding agents with [`npx skills`][npx-skills], no 
 
 ```bash
 # Install the skills for a coding agent, named by its own identifier
-npx skills add slackapi/slack-skills-plugin -a <agent>
+npx skills add slackapi/slack-skills-plugin -y -a <agent>
 
 # For example, Gemini CLI or OpenCode
-npx skills add slackapi/slack-skills-plugin -a gemini-cli
-npx skills add slackapi/slack-skills-plugin -a opencode
+npx skills add slackapi/slack-skills-plugin -y -a gemini-cli
+npx skills add slackapi/slack-skills-plugin -y -a opencode
 ```
 
 Other popular agents include `crush`, `devin`, `hermes-agent`, `openclaw`, and `pi`. See [supported agents][npx-skills] for the full list of agents and their identifiers. Add `-g` to install for your user instead of the current project.
+
+The `-y` flag installs every skill without prompting. Drop it to choose skills from a list, or pass `-s <skill>` to name the ones you want.
 
 This path carries the skills only: no commands, and no MCP server.
 

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -52,14 +52,16 @@ The skills can be installed on their own into other coding agents with [`npx ski
 
 ```bash
 # Install the skills for a coding agent, named by its own identifier
-npx skills add slackapi/slack-skills-plugin -a <agent>
+npx skills add slackapi/slack-skills-plugin -y -a <agent>
 
 # For example, Gemini CLI or OpenCode
-npx skills add slackapi/slack-skills-plugin -a gemini-cli
-npx skills add slackapi/slack-skills-plugin -a opencode
+npx skills add slackapi/slack-skills-plugin -y -a gemini-cli
+npx skills add slackapi/slack-skills-plugin -y -a opencode
 ```
 
 Other popular agents include `crush`, `devin`, `hermes-agent`, `openclaw`, and `pi`. See [supported agents](https://github.com/vercel-labs/skills#supported-agents) for the full list of agents and their identifiers.
+
+The `-y` flag installs every skill without prompting. Drop it to choose skills from a list, or pass `-s <skill>` to name the ones you want.
 
 This installs the skills only. There is no MCP server on this path, which causes some issues (e.g., the slack-search skill cannot query your workspace).
 


### PR DESCRIPTION
### Summary

This pull request removes an interactive prompt from the `npx skills` install path, so a developer following the documented command gets the skills installed in one step instead of having to answer a question first.

Running the command as documented today stops at a `Select skills to install` multiselect that starts with **nothing** selected, so the developer has to arrow, space-select, and confirm before anything is written. Adding `-y` installs all eight skills straight through. The flag is applied in all three places the command appears: `README.md`, `docs/slack-skills-plugin.md` (the page published to docs.slack.dev), and the unreleased changeset that documents this path.

A sentence is added under each code block so the interactive choice is still discoverable: drop `-y` to pick from the list, or pass `-s <skill>` to name skills explicitly.

### Testing

- Ran `npx skills add slackapi/slack-skills-plugin -a opencode` in a scratch project: stops at `Select skills to install`, `0/8` selected, and writes nothing until confirmed.
- Ran `npx skills add slackapi/slack-skills-plugin -y -a opencode` in the same project: prints `Installing all 8 skills` and completes with all eight in `.agents/skills/` plus a `skills-lock.json`.
- `rumdl check .` clean at 19 files.

### Notes

- `-y` is documented by the tool as `Skip confirmation prompts`, and with `-a <agent>` already supplied it is the only remaining prompt on this path.
- No new changeset. The existing `.changeset/npx-skills-install-path.md` documents this same command and has not shipped yet, so its command block is corrected in place rather than adding a second release note about the same flag.
- The docs page has a pre-existing missing-trailing-newline violation that #145 fixes; left alone here to avoid conflicting with that PR.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass. Docs-only change; `rumdl check .` run instead, and the evaluation suite needs `GEMINI_API_KEY` plus `SLACK_MCP_TOKEN`, which are not available locally.