### PR TITLE
feat: support developer sandboxes, free, and paid teams as install targets

### DIFF
--- a/.changeset/free-team-install-targets.md
+++ b/.changeset/free-team-install-targets.md
@@ -1,0 +1,5 @@
+---
+"slack": minor
+---
+
+Offer a ranked set of install targets instead of treating a developer sandbox as the only option. `create-slack-app` Step 3 now presents a sandbox (recommended), a Free Team (second choice), or an existing production workspace (last resort, usually gated by admin app approval), and `test-slack-app` accepts a throwaway Free Team as a safe place to test. Also runs `sandbox list` and `sandbox create` non-interactively with `--team`, `--name`, and `--password`.

--- a/.changeset/free-team-install-targets.md
+++ b/.changeset/free-team-install-targets.md
@@ -2,4 +2,4 @@
 "slack": minor
 ---
 
-Offer a ranked set of install targets instead of treating a developer sandbox as the only option. `create-slack-app` Step 3 now presents a sandbox (recommended), a Free Team (second choice), or an existing production workspace (last resort, usually gated by admin app approval), and `test-slack-app` accepts a throwaway Free Team as a safe place to test. Also runs `sandbox list` and `sandbox create` non-interactively with `--team`, `--name`, and `--password`.
+Support developer sandboxes, free, and paid teams as install targets, instead of treating a developer sandbox as the only option. `create-slack-app` Step 3 now presents a sandbox (recommended), a Free Team (second choice), or an existing production workspace (last resort, usually gated by admin app approval), and `test-slack-app` accepts a throwaway Free Team as a safe place to test. Also runs `sandbox list` and `sandbox create` non-interactively with `--team`, `--name`, and `--password`.

--- a/.changeset/free-team-install-targets.md
+++ b/.changeset/free-team-install-targets.md
@@ -2,4 +2,4 @@
 "slack": minor
 ---
 
-Support developer sandboxes, free, and paid teams as install targets, instead of treating a developer sandbox as the only option. `create-slack-app` Step 3 now presents a sandbox (recommended), a Free Team (second choice), or an existing production workspace (last resort, usually gated by admin app approval), and `test-slack-app` accepts a throwaway Free Team as a safe place to test. Also runs `sandbox list` and `sandbox create` non-interactively with `--team`, `--name`, and `--password`.
+Support developer sandboxes, free, and paid teams as install targets, instead of treating a developer sandbox as the only option. `create-slack-app` Step 3 now presents a sandbox (recommended), a Free Team (second choice), or an existing production workspace (last resort, usually gated by admin app approval), and `test-slack-app` accepts a Free Team as a safe place to test. Also runs `sandbox list` and `sandbox create` non-interactively with `--team`, `--name`, and `--password`.

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -82,4 +82,4 @@ Most of the skills work on their own, without a connection to the [Slack MCP ser
 | `slack-docs` | Find and read the right Slack developer docs page, so Slack platform answers come from the live docs rather than memory. | _"How does the Events API delivery model work?"_ |
 | `slack-messaging` | Compose well-formatted Slack messages using standard markdown. | _"Draft a release announcement message with a bulleted list of changes."_ |
 | `slack-search` | Search Slack effectively to find messages, files, channels, and people. Requires a Slack MCP Server connection. | _"Find the channel where we discuss the platform roadmap."_ |
-| `test-slack-app` | Run an existing Slack app in a throwaway workspace, a [developer sandbox](/tools/developer-sandboxes) or a Free Team, and get guided, source-specific steps to confirm it works in Slack. | _"Help me check that my Slack app actually works."_ |
+| `test-slack-app` | Run an existing Slack app in a [developer sandbox](/tools/developer-sandboxes) or a Free Team, and get guided, source-specific steps to confirm it works in Slack. | _"Help me check that my Slack app actually works."_ |

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -82,4 +82,4 @@ Most of the skills work on their own, without a connection to the [Slack MCP ser
 | `slack-docs` | Find and read the right Slack developer docs page, so Slack platform answers come from the live docs rather than memory. | _"How does the Events API delivery model work?"_ |
 | `slack-messaging` | Compose well-formatted Slack messages using standard markdown. | _"Draft a release announcement message with a bulleted list of changes."_ |
 | `slack-search` | Search Slack effectively to find messages, files, channels, and people. Requires a Slack MCP Server connection. | _"Find the channel where we discuss the platform roadmap."_ |
-| `test-slack-app` | Run an existing Slack app in a [developer sandbox](/tools/developer-sandboxes) and get guided, source-specific steps to confirm it works in Slack. | _"Help me check that my Slack app actually works."_ |
+| `test-slack-app` | Run an existing Slack app in a throwaway workspace, a [developer sandbox](/tools/developer-sandboxes) or a Free Team, and get guided, source-specific steps to confirm it works in Slack. | _"Help me check that my Slack app actually works."_ |

--- a/docs/slack-skills-plugin.md
+++ b/docs/slack-skills-plugin.md
@@ -82,4 +82,4 @@ Most of the skills work on their own, without a connection to the [Slack MCP ser
 | `slack-docs` | Find and read the right Slack developer docs page, so Slack platform answers come from the live docs rather than memory. | _"How does the Events API delivery model work?"_ |
 | `slack-messaging` | Compose well-formatted Slack messages using standard markdown. | _"Draft a release announcement message with a bulleted list of changes."_ |
 | `slack-search` | Search Slack effectively to find messages, files, channels, and people. Requires a Slack MCP Server connection. | _"Find the channel where we discuss the platform roadmap."_ |
-| `test-slack-app` | Run an existing Slack app in a [developer sandbox](/tools/developer-sandboxes) or a Free Team, and get guided, source-specific steps to confirm it works in Slack. | _"Help me check that my Slack app actually works."_ |
+| `test-slack-app` | Run an existing Slack app somewhere safe, like a [developer sandbox](/tools/developer-sandboxes), and get guided, source-specific steps to confirm it works in Slack. | _"Help me check that my Slack app actually works."_ |

--- a/skills/create-slack-app/SKILL.md
+++ b/skills/create-slack-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-slack-app
-description: 'Use when a developer wants to create, scaffold, or bootstrap a new Slack app or agent from scratch with the Slack CLI. Covers prerequisites, sandbox setup, authentication, and creating + running a project from a Bolt (JS or Python) template locally. Trigger on "create a Slack app", "new Bolt app", "start a Slack agent".'
+description: 'Use when a developer wants to create, scaffold, or bootstrap a new Slack app or agent from scratch with the Slack CLI. Covers prerequisites, authentication, choosing a workspace to install into (developer sandbox, Free Team, or production), and creating + running a project from a Bolt (JS or Python) template locally. Trigger on "create a Slack app", "new Bolt app", "start a Slack agent".'
 argument-hint: "[bolt-js | bolt-python]"
 ---
 
@@ -8,7 +8,7 @@ argument-hint: "[bolt-js | bolt-python]"
 
 Help the developer create a Slack app or agent using Bolt for **$0**.
 
-This skill walks through the full setup: prerequisites, authentication, sandbox creation, project scaffolding from a template, and running the app locally.
+This skill walks through the full setup: prerequisites, authentication, choosing a workspace to install into, project scaffolding from a template, and running the app locally.
 
 ---
 
@@ -39,20 +39,60 @@ Wait for confirmation that authentication succeeded before proceeding.
 
 ---
 
-## Step 3: Set Up a Developer Sandbox
+## Step 3: Choose Where to Install the App
 
-Run `SLACK_CMD sandbox list` to check if the developer already has a sandbox.
+The app needs a Slack workspace to install into. Three targets work and they are not equivalent. Use AskUserQuestion to let the developer pick, presenting them in this order:
+
+| Target | Best for | Cost of entry |
+|--------|----------|---------------|
+| **Developer sandbox** (recommended) | Anything the developer plans to keep building on. A free, throwaway Slack org isolated from real users. | Needs a Slack Developer Program account, which is free to join. |
+| **Free Team** (second choice) | Starting right now, when Developer Program signup is the thing in the way. A free workspace the developer creates and owns. | Capped at 10 apps per workspace. |
+| **Existing production workspace** (last resort) | Only when the app must reach real data or real coworkers. | Usually gated by admin approval, and the developer may not be the admin. |
+
+Then follow the matching sub-step below. Whichever target they pick, authentication is the same Step 2 flow: the `/slackauthticket` command works in any workspace the developer belongs to, so there is no sandbox-specific login.
+
+### 3a. Developer sandbox (recommended)
+
+List existing sandboxes. Pass `--team` so the CLI does not stop to ask which authentication to use (get the team ID from `SLACK_CMD auth list`):
+
+```bash
+SLACK_CMD sandbox list --team <team_id>
+```
 
 - **If a sandbox exists**: Show it and confirm they want to use it.
-- **If no sandbox exists**: Tell the developer to create one:
+- **If no sandbox exists**: Create one. Ask the developer for a name and a password with AskUserQuestion, then run:
 
-  ```text
-  ! SLACK_CMD sandbox create
+  ```bash
+  SLACK_CMD sandbox create --team <team_id> --name <sandbox-name> --password <password>
   ```
 
-  Alternatively, they can create one at <https://api.slack.com/developer-program/sandboxes> or join the Developer Program at <https://api.slack.com/developer-program/join>.
+  **Important**: the password is a credential. Do NOT echo it, restate it, or write it into a summary. Pass it straight to the command, the same rule Step 4c applies to API keys.
 
-Wait for confirmation that a sandbox is available before proceeding.
+  Sandboxes can also be created in the browser at <https://api.slack.com/developer-program/sandboxes>.
+
+**If the developer has no Developer Program account**, `sandbox list` returns nothing useful, because sandboxes belong to the developer program account whose email matches the authenticated user rather than to the workspace. Point them at <https://api.slack.com/developer-program/join>, and offer the Free Team path in 3b as a way to start building now rather than waiting on signup.
+
+Once the sandbox exists, have the developer log into it with the Step 2 flow before continuing.
+
+### 3b. Free Team (second choice)
+
+A Free Team is an ordinary Slack workspace on the free plan. The developer creates one at <https://slack.com/get-started>, then logs into it with the Step 2 flow.
+
+What to tell them:
+
+- Everything this skill builds works there. Bolt apps install and run fine on the free plan.
+- The workspace is capped at **10 apps**. Past that the CLI reports `service_limits_exceeded`.
+- Keep it a throwaway. A Free Team they have invited coworkers into is a production workspace for the purposes of 3c.
+
+### 3c. Existing production workspace (last resort)
+
+Only when the app genuinely needs real data or real users. Warn the developer before they log in:
+
+- **Admin app approval (AAA) is likely to block the install.** It is always on for Enterprise Grid organizations and can be switched on in standalone workspaces. When it applies, the install in Step 5 stops and asks whether to request approval, and then the developer waits on an admin.
+- To send that request without the prompt, set `SLACK_AUTO_REQUEST_AAA=1` in the environment. It is an environment variable, not a CLI flag.
+- If approval is denied or slow, fall back to 3a or 3b instead of fighting it.
+
+Wait for confirmation that a target workspace exists and is authenticated before proceeding.
 
 ---
 
@@ -163,7 +203,9 @@ cd my-slack-agent && SLACK_CMD env set ANTHROPIC_API_KEY sk-ant-...
 
 Use the `slack:slack-cli` skill — **Step 6: Running an App Locally (`slack run`)** — to resolve the app or team target and start the dev server in the background.
 
-Tell the developer their app is now running and installed in their sandbox workspace, and that file changes will auto-reload it.
+Tell the developer their app is now running and installed in the workspace they chose in Step 3, and that file changes will auto-reload it.
+
+If the install stops on an admin approval request, they picked a workspace with AAA turned on: see Step 3c for the options.
 
 ---
 
@@ -182,5 +224,6 @@ After the app is running, suggest next steps:
 
 - `SLACK_CMD` is a placeholder — always substitute the actual command name resolved in Step 1a (typically `slack`, but may be an alias).
 - This skill focuses on **Bolt for JavaScript** and **Bolt for Python** only. Do not suggest Deno, workflow apps, or `slack deploy` (hosted deployment).
-- `SLACK_CMD sandbox create` is an interactive command that requires user input — it does NOT work with the `! command` prefix in Claude Code. Instead, tell the developer to run it in a **new terminal window**.
+- `SLACK_CMD sandbox create` prompts for a name and password only when those flags are missing. Supply `--team`, `--name`, and `--password` and it runs non-interactively, so you can run it yourself rather than handing it to the developer. `SLACK_CMD sandbox list` needs `--team` for the same reason: without it the CLI prompts for which authentication to use.
+- Free Teams and developer sandboxes both support everything this skill builds. The CLI's `free_team_not_allowed` error is scoped to low-code workflow and function apps, which this skill does not create.
 - If the developer hits issues, suggest `SLACK_CMD doctor` to diagnose their setup.

--- a/skills/create-slack-app/SKILL.md
+++ b/skills/create-slack-app/SKILL.md
@@ -45,7 +45,7 @@ The app needs a Slack workspace to install into. Three targets work and they are
 
 | Target | Best for | Cost of entry |
 |--------|----------|---------------|
-| **Developer sandbox** (recommended) | Anything the developer plans to keep building on. A free, throwaway Slack org isolated from real users. | Needs a Slack Developer Program account, which is free to join. |
+| **Developer sandbox** (recommended) | Anything the developer plans to keep building on. A free Slack org isolated from real users. | Needs a Slack Developer Program account, which is free to join. |
 | **Free Team** (second choice) | Starting right now, when Developer Program signup is the thing in the way. A free workspace the developer creates and owns. | Capped at 10 apps per workspace. |
 | **Existing production workspace** (last resort) | Only when the app must reach real data or real coworkers. | Usually gated by admin approval, and the developer may not be the admin. |
 
@@ -82,7 +82,7 @@ What to tell them:
 
 - Everything this skill builds works there. Bolt apps install and run fine on the free plan.
 - The workspace is capped at **10 apps**. Past that the CLI reports `service_limits_exceeded`.
-- Keep it a throwaway. A Free Team they have invited coworkers into is a production workspace for the purposes of 3c.
+- Do not invite coworkers into it. A Free Team with real users in it is a production workspace for the purposes of 3c.
 
 ### 3c. Existing production workspace (last resort)
 

--- a/skills/create-slack-app/SKILL.md
+++ b/skills/create-slack-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-slack-app
-description: 'Use when a developer wants to create, scaffold, or bootstrap a new Slack app or agent from scratch with the Slack CLI. Covers prerequisites, authentication, choosing a workspace to install into (developer sandbox, Free Team, or production), and creating + running a project from a Bolt (JS or Python) template locally. Trigger on "create a Slack app", "new Bolt app", "start a Slack agent".'
+description: 'Use when a developer wants to create, scaffold, or bootstrap a new Slack app or agent from scratch with the Slack CLI. Covers prerequisites, authentication, choosing a workspace to install into, and creating + running a project from a Bolt (JS or Python) template locally. Trigger on "create a Slack app", "new Bolt app", "start a Slack agent".'
 argument-hint: "[bolt-js | bolt-python]"
 ---
 

--- a/skills/create-slack-app/SKILL.md
+++ b/skills/create-slack-app/SKILL.md
@@ -45,8 +45,8 @@ The app needs a Slack workspace to install into. Three targets work and they are
 
 | Target | Best for | Cost of entry |
 |--------|----------|---------------|
-| **Developer sandbox** (recommended) | Anything the developer plans to keep building on. A free Slack org isolated from real users. | Needs a Slack Developer Program account, which is free to join. |
-| **Free Team** (second choice) | Starting right now, when Developer Program signup is the thing in the way. A free workspace the developer creates and owns. | Capped at 10 apps per workspace. |
+| **Developer sandbox** (recommended) | Anything the developer plans to keep building on. A free Enterprise Grid org isolated from real users, so org-level features are testable. | Needs a Slack Developer Program account, which is free to join. |
+| **Free Team** (second choice) | Starting right now, when Developer Program signup is the thing in the way. A free workspace the developer creates and owns. | Capped at 10 apps per workspace, and no Enterprise Grid org features. |
 | **Existing production workspace** (last resort) | Only when the app must reach real data or real coworkers. | Usually gated by admin approval, and the developer may not be the admin. |
 
 Then follow the matching sub-step below. Whichever target they pick, authentication is the same Step 2 flow: the `/slackauthticket` command works in any workspace the developer belongs to, so there is no sandbox-specific login.
@@ -82,6 +82,7 @@ What to tell them:
 
 - Everything this skill builds works there. Bolt apps install and run fine on the free plan.
 - The workspace is capped at **10 apps**. Past that the CLI reports `service_limits_exceeded`.
+- **It is a standalone workspace, not an Enterprise Grid org**, unlike a developer sandbox. Anything org-level is therefore untestable: org-wide app installs and org-level app grants, the `admin.*` API methods (which need Business+ or Enterprise Grid), and multi-workspace behaviour generally. If the app targets those, use a sandbox instead.
 - Do not invite coworkers into it. A Free Team with real users in it is a production workspace for the purposes of 3c.
 
 ### 3c. Existing production workspace (last resort)

--- a/skills/create-slack-app/SKILL.md
+++ b/skills/create-slack-app/SKILL.md
@@ -51,6 +51,8 @@ The app needs a Slack workspace to install into. Three targets work and they are
 
 Then follow the matching sub-step below. Whichever target they pick, authentication is the same Step 2 flow: the `/slackauthticket` command works in any workspace the developer belongs to, so there is no sandbox-specific login.
 
+Whichever sub-step you follow, wait for confirmation that a target workspace exists and is authenticated before proceeding.
+
 ### 3a. Developer sandbox (recommended)
 
 List existing sandboxes. Pass `--team` so the CLI does not stop to ask which authentication to use (get the team ID from `SLACK_CMD auth list`):
@@ -58,6 +60,8 @@ List existing sandboxes. Pass `--team` so the CLI does not stop to ask which aut
 ```bash
 SLACK_CMD sandbox list --team <team_id>
 ```
+
+**If the developer has no Developer Program account**, `sandbox list` returns nothing useful, because sandboxes belong to the developer program account whose email matches the authenticated user rather than to the workspace. Point them at <https://api.slack.com/developer-program/join>, and offer the Free Team path in 3b as a way to start building now rather than waiting on signup.
 
 - **If a sandbox exists**: Show it and confirm they want to use it.
 - **If no sandbox exists**: Create one. Ask the developer for a name and a password with AskUserQuestion, then run:
@@ -69,8 +73,6 @@ SLACK_CMD sandbox list --team <team_id>
   **Important**: the password is a credential. Do NOT echo it, restate it, or write it into a summary. Pass it straight to the command, the same rule Step 4c applies to API keys.
 
   Sandboxes can also be created in the browser at <https://api.slack.com/developer-program/sandboxes>.
-
-**If the developer has no Developer Program account**, `sandbox list` returns nothing useful, because sandboxes belong to the developer program account whose email matches the authenticated user rather than to the workspace. Point them at <https://api.slack.com/developer-program/join>, and offer the Free Team path in 3b as a way to start building now rather than waiting on signup.
 
 Once the sandbox exists, have the developer log into it with the Step 2 flow before continuing.
 
@@ -92,8 +94,6 @@ Only when the app genuinely needs real data or real users. Warn the developer be
 - **Admin app approval (AAA) is likely to block the install.** It is always on for Enterprise Grid organizations and can be switched on in standalone workspaces. When it applies, the install in Step 5 stops and asks whether to request approval, and then the developer waits on an admin.
 - To send that request without the prompt, set `SLACK_AUTO_REQUEST_AAA=1` in the environment. It is an environment variable, not a CLI flag.
 - If approval is denied or slow, fall back to 3a or 3b instead of fighting it.
-
-Wait for confirmation that a target workspace exists and is authenticated before proceeding.
 
 ---
 

--- a/skills/slack-cli/SKILL.md
+++ b/skills/slack-cli/SKILL.md
@@ -126,6 +126,8 @@ Slack auth is **per-team**, not a single boolean. Run the seamless login flow be
 
 `SLACK_CMD auth list` showing other teams is **not** a reason to skip login — those are different teams. Ask the developer which team they want, then run the flow.
 
+The flow below is the same for every kind of workspace. `/slackauthticket` works in any workspace the developer belongs to, whether that is a developer sandbox, a Free Team, or a production workspace, so there is no sandbox-specific login. Which target to prefer is the `slack:create-slack-app` skill's call (**Step 3: Choose Where to Install the App**).
+
 ### Inspect existing auth (optional)
 
 ```bash

--- a/skills/test-slack-app/SKILL.md
+++ b/skills/test-slack-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-slack-app
-description: Use when a developer wants to test, try out, smoke-test, verify, or confirm that a Slack app built with the Slack CLI (or a plain Bolt app) actually works, by running it in a developer sandbox (never a workspace with real users) with `slack run` and exercising its real slash commands, shortcuts, events, actions, modals, App Home, and assistant surfaces. Also covers `slack doctor` and `slack manifest validate` health checks before hands-on testing.
+description: Use when a developer wants to test, try out, smoke-test, verify, or confirm that a Slack app built with the Slack CLI (or a plain Bolt app) actually works, by running it in a throwaway workspace (a developer sandbox or a Free Team, never a workspace with real users) with `slack run` and exercising its real slash commands, shortcuts, events, actions, modals, App Home, and assistant surfaces. Also covers `slack doctor` and `slack manifest validate` health checks before hands-on testing.
 ---
 
 # Test Slack App
@@ -9,7 +9,7 @@ Help a developer confirm that a Slack app they already built actually works. Thi
 
 The approach is simple and safe:
 
-1. **Run the app in a developer sandbox:** a free, throwaway Slack org for building and testing, never a workspace with real coworkers in it.
+1. **Run the app in a throwaway workspace:** a developer sandbox for preference, or a Free Team the developer created for this. Never a workspace with real coworkers in it.
 2. **Read the app's source** to learn what it actually listens for.
 3. **Hand the developer concrete steps** to perform in Slack, then help them confirm the app responds.
 
@@ -23,13 +23,14 @@ This is guided manual checking, not an automated test suite: you drive the setup
 
 Use the `slack:slack-cli` skill (**Step 1: Detect the Slack CLI**) to check whether the public Slack CLI is installed and resolve its command name. The fingerprint check, alias fallback, and install instructions all live there; do not duplicate them here. Refer to the resolved command as `SLACK_CMD` throughout. If the CLI is not installed, guide the developer through that same step to install it, since running the app needs it.
 
-### 1b. Make sure there is a developer sandbox to test in
+### 1b. Make sure there is a throwaway workspace to test in
 
-Testing belongs in a developer sandbox, never a workspace with real coworkers in it.
+Testing belongs in a workspace nobody is working in: a developer sandbox for preference, or a Free Team the developer created for this. Never a workspace with real coworkers in it.
 
 - **Explain it from the live docs, not from here.** Use the `slack:slack-docs` skill to fetch and summarize <https://docs.slack.dev/tools/developer-sandboxes.md>, so the recommendation always reflects the current docs rather than a copy that drifts out of date. Tell the developer that Slack recommends a sandbox for building and testing apps.
 - **Find the current target.** Run `SLACK_CMD auth list` for the authenticated workspaces and their team IDs, and, from the project directory, `SLACK_CMD app list` for the apps already installed and their IDs.
-- **Confirm it is a sandbox.** The CLI cannot tell a sandbox apart from a workspace with real users, so ask the developer to confirm the target is a developer sandbox. If there is no sandbox yet, set one up with the `slack:create-slack-app` skill (**Step 3: Set Up a Developer Sandbox**), which owns the `sandbox list` / `sandbox create` flow and the Developer Program links. Creating a sandbox happens in the browser, so have the developer come back here once the sandbox exists and they have logged into it.
+- **Confirm the target is safe.** The CLI cannot tell a sandbox, a throwaway Free Team, and a workspace full of real users apart, so ask the developer which one they are pointed at. A sandbox or a Free Team they created for this is fine. A workspace with coworkers in it is not: stop and get them onto one of the other two.
+- **If there is no safe target yet**, set one up with the `slack:create-slack-app` skill (**Step 3: Choose Where to Install the App**), which owns the ranked targets, the `sandbox list` / `sandbox create` flow, and the Developer Program links. Either path finishes in the browser, so have the developer come back here once the workspace exists and they have logged into it.
 
 ### 1c. Quick health check
 
@@ -48,13 +49,13 @@ Whichever path you use below, first turn the app's log level up to debug so you 
 
 ### CLI-managed apps (recommended)
 
-Follow **Step 6: Running an App Locally (`slack run`)** in the `slack:slack-cli` skill to start the local dev server in the background. This also installs the app into the target workspace, which matters for a fresh sandbox where nothing is installed yet. Once it is running, file changes auto-reload.
+Follow **Step 6: Running an App Locally (`slack run`)** in the `slack:slack-cli` skill to start the local dev server in the background. This also installs the app into the target workspace, which matters for a fresh sandbox or Free Team where nothing is installed yet. Once it is running, file changes auto-reload.
 
 ### Plain Bolt apps without the CLI (best-effort)
 
 If the app is a plain Bolt app started with `node` or `python` rather than the Slack CLI, this skill can still help, but the run path is best-effort and not the primary flow:
 
-- Point the app at the sandbox: set its bot and app-level tokens (from the sandbox app's settings) in the environment or the `.env` file the app reads.
+- Point the app at the test workspace: set its bot and app-level tokens (from that workspace's app settings) in the environment or the `.env` file the app reads.
 - Prefer socket mode so the app needs no public URL. This works only if the app is coded for socket mode and the app-level token has `connections:write`; adding tokens to an app scaffolded for HTTP will not deliver events.
 - Start the app with its own command (for example `npm start` or `python app.py`) and watch its logs.
 
@@ -84,7 +85,7 @@ Name the concrete identifiers you find (the actual command and callback names), 
 
 For every registered interaction, give the developer a concrete step and what a working app should do in response. A few spots are non-obvious, so spell them out:
 
-- **Slash command** → type the command (for example `/ship`) in a channel or DM in the sandbox → expect the response the handler sends.
+- **Slash command** → type the command (for example `/ship`) in a channel or DM in the test workspace → expect the response the handler sends.
 - **Global shortcut** → open the shortcuts menu (the lightning-bolt or `+` button in the message composer, depending on your client) and pick it → expect the modal or message it opens.
 - **Message shortcut** → hover a message, open **More actions** (the `⋯` menu), pick the shortcut → expect its response.
 - **Event** such as `app_mention` → @-mention the app in a channel it belongs to → expect its reply.

--- a/skills/test-slack-app/SKILL.md
+++ b/skills/test-slack-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-slack-app
-description: Use when a developer wants to test, try out, smoke-test, verify, or confirm that a Slack app built with the Slack CLI (or a plain Bolt app) actually works, by running it in a throwaway workspace (a developer sandbox or a Free Team, never a workspace with real users) with `slack run` and exercising its real slash commands, shortcuts, events, actions, modals, App Home, and assistant surfaces. Also covers `slack doctor` and `slack manifest validate` health checks before hands-on testing.
+description: Use when a developer wants to test, try out, smoke-test, verify, or confirm that a Slack app built with the Slack CLI (or a plain Bolt app) actually works, by running it in a developer sandbox or a Free Team, never a workspace with real users, with `slack run` and exercising its real slash commands, shortcuts, events, actions, modals, App Home, and assistant surfaces. Also covers `slack doctor` and `slack manifest validate` health checks before hands-on testing.
 ---
 
 # Test Slack App
@@ -9,7 +9,7 @@ Help a developer confirm that a Slack app they already built actually works. Thi
 
 The approach is simple and safe:
 
-1. **Run the app in a throwaway workspace:** a developer sandbox for preference, or a Free Team the developer created for this. Never a workspace with real coworkers in it.
+1. **Run the app in a developer sandbox or a Free Team:** a sandbox for preference, or a Free Team the developer created for this. Never a workspace with real coworkers in it.
 2. **Read the app's source** to learn what it actually listens for.
 3. **Hand the developer concrete steps** to perform in Slack, then help them confirm the app responds.
 
@@ -23,13 +23,13 @@ This is guided manual checking, not an automated test suite: you drive the setup
 
 Use the `slack:slack-cli` skill (**Step 1: Detect the Slack CLI**) to check whether the public Slack CLI is installed and resolve its command name. The fingerprint check, alias fallback, and install instructions all live there; do not duplicate them here. Refer to the resolved command as `SLACK_CMD` throughout. If the CLI is not installed, guide the developer through that same step to install it, since running the app needs it.
 
-### 1b. Make sure there is a throwaway workspace to test in
+### 1b. Make sure there is a safe workspace to test in
 
 Testing belongs in a workspace nobody is working in: a developer sandbox for preference, or a Free Team the developer created for this. Never a workspace with real coworkers in it.
 
 - **Explain it from the live docs, not from here.** Use the `slack:slack-docs` skill to fetch and summarize <https://docs.slack.dev/tools/developer-sandboxes.md>, so the recommendation always reflects the current docs rather than a copy that drifts out of date. Tell the developer that Slack recommends a sandbox for building and testing apps.
 - **Find the current target.** Run `SLACK_CMD auth list` for the authenticated workspaces and their team IDs, and, from the project directory, `SLACK_CMD app list` for the apps already installed and their IDs.
-- **Confirm the target is safe.** The CLI cannot tell a sandbox, a throwaway Free Team, and a workspace full of real users apart, so ask the developer which one they are pointed at. A sandbox or a Free Team they created for this is fine. A workspace with coworkers in it is not: stop and get them onto one of the other two.
+- **Confirm the target is safe.** The CLI cannot tell a sandbox, a Free Team, and a workspace full of real users apart, so ask the developer which one they are pointed at. A sandbox or a Free Team they created for this is fine. A workspace with coworkers in it is not: stop and get them onto one of the other two.
 - **If there is no safe target yet**, set one up with the `slack:create-slack-app` skill (**Step 3: Choose Where to Install the App**), which owns the ranked targets, the `sandbox list` / `sandbox create` flow, and the Developer Program links. Either path finishes in the browser, so have the developer come back here once the workspace exists and they have logged into it.
 
 ### 1c. Quick health check


### PR DESCRIPTION
### Summary

This pull request adds developer sandboxes, free, and paid teams as install
targets to get a developer without a Slack Developer Program account to a
running app, instead of treating a developer sandbox as the only option.

`create-slack-app` Step 3 was "Set Up a Developer Sandbox", written as a hard
requirement. The step is now "Choose Where to Install the App" and ranks
three targets:

- **Developer sandbox** (recommended). The existing path, still first.
- **Free Team** (second choice). A free workspace the developer creates, for
  starting now when program signup is the thing in the way.
- **Existing production workspace** (last resort). Carries a warning that admin
  app approval usually gates the install, and that `SLACK_AUTO_REQUEST_AAA` is an
  environment variable rather than a CLI flag.

`test-slack-app` now accepts a Free Team as a safe place to test and
points at the new step when there is no safe target yet.

### Preview

**Creating a new app:**

<img width="1066" height="727" alt="image" src="https://github.com/user-attachments/assets/d4e8d95c-b900-4d6d-b674-5c9c3956fa77" />

**Testing an app:**

<img width="1066" height="727" alt="image" src="https://github.com/user-attachments/assets/60c304c2-1746-4afc-9ee9-40fed42457b1" />

### Testing

1. Logout of your Slack CLI auths
2. Ask coding agent to create a new Slack app
3. Confirm it recommends the 3 types of Slack Teams
4. After creation, ask how to test the Slack app
5. Confirm it checks your Slack Team type, discouraging Production Teams

### Notes

- N/A

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-skills-plugin/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `make test` and the tests pass.
